### PR TITLE
Fix NintendoRGBA32 outputting a BGRA image

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+root = true
+
+[*]
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = crlf
+
+[*.cs]
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_prefer_braces = when_multiline:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = false:suggestion
+csharp_new_line_before_open_brace = all
+csharp_style_unused_value_assignment_preference = unused_local_variable:suggestion
+
+[*.{cs,vb}]
+indent_size = 4
+tab_width = 4
+
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = none

--- a/Pitfall.sln
+++ b/Pitfall.sln
@@ -5,7 +5,12 @@ VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TexConvert", "TexConvert\TexConvert.csproj", "{690A288B-72BF-4B39-8E9E-DA93F2B69184}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModelConvert", "ModelConvert\ModelConvert.csproj", "{BCE174C4-15CF-4104-82CA-BA302FE8BCF7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelConvert", "ModelConvert\ModelConvert.csproj", "{BCE174C4-15CF-4104-82CA-BA302FE8BCF7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{24E5D8F8-BB92-4628-A8EE-B0C7F793ECB9}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TexConvert/Formats/NintendoRGBA32.cs
+++ b/TexConvert/Formats/NintendoRGBA32.cs
@@ -1,6 +1,5 @@
 ﻿using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using static TexConvert.TexConvert;
 
 namespace TexConvert.Formats;
 
@@ -11,15 +10,14 @@ class NintendoRGBA32 : IPixelFormat
     public Image<Rgba32> Convert(in TextureHeader header, byte[] data)
     {
         // Note this is not the weird bit-interleaved Nintendo RGBA32 format, yay
-        var pixels = new Rgba32[header.PixelCount];
-        for (int i = 0; i < header.PixelCount; i++)
-        {
-            pixels[i] = new Rgba32(
-                data[i * 4 + 2],
-                data[i * 4 + 1],
-                data[i * 4 + 0],
-                data[i * 4 + 3]);
-        }
+        var pixels = Enumerable
+            .Range(0, header.PixelCount)
+            .Select(i => new Rgba32(
+                data[(i * 4) + 0],
+                data[(i * 4) + 1],
+                data[(i * 4) + 2],
+                data[(i * 4) + 3]))
+            .ToArray();
         return Image.LoadPixelData(pixels, header.Width, header.Height);
     }
 }


### PR DESCRIPTION
As mentioned on Discord, comparing with Dolphin texture dump made me realize the Blue and Red channels were flipped. There's only 9 textures with that format.

Also added an `.editorconfig` wit minimal configuration so that Visual Studio's Code Cleanup respects your code style (at least for this file).
